### PR TITLE
Путевые точки

### DIFF
--- a/bleak harbor/Assets/Prefabs/Waypoint.prefab
+++ b/bleak harbor/Assets/Prefabs/Waypoint.prefab
@@ -1,0 +1,56 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8236407040451445320
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6013258534156695908}
+  - component: {fileID: 7559703414755690916}
+  - component: {fileID: 3170290366780529544}
+  m_Layer: 0
+  m_Name: Waypoint
+  m_TagString: EditorOnly
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6013258534156695908
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8236407040451445320}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.35277557, y: -0.44460058, z: 0.31677794}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &7559703414755690916
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8236407040451445320}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &3170290366780529544
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8236407040451445320}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6e76c6accbeada4c8d2d9a2f024071f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  next: {fileID: 0}
+  stopHere: 0

--- a/bleak harbor/Assets/Scenes/AI test scene.unity
+++ b/bleak harbor/Assets/Scenes/AI test scene.unity
@@ -130,7 +130,7 @@ GameObject:
   m_Component:
   - component: {fileID: 127082247}
   m_Layer: 0
-  m_Name: Waypoint
+  m_Name: Waypoints
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -149,6 +149,8 @@ Transform:
   m_Children:
   - {fileID: 1249976210}
   - {fileID: 1182779761}
+  - {fileID: 302049290}
+  - {fileID: 1698420890}
   m_Father: {fileID: 0}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -231,6 +233,85 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 138996721}
   m_CullTransparentMesh: 0
+--- !u!1001 &226924142
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 127082247}
+    m_Modifications:
+    - target: {fileID: 8236407040451445320, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_Name
+      value: Waypoint (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8236407040451445320, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 14.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.31677794
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3170290366780529544, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: next
+      value: 
+      objectReference: {fileID: 1249976209}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f2789e2148f46e040bc8d2f1f4814ce1, type: 3}
 --- !u!1 &292991391
 GameObject:
   m_ObjectHideFlags: 0
@@ -266,7 +347,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   speed: 20000
   body: {fileID: 0}
-  fraction: 0
+  fraction: 1
   start: {fileID: 1249976209}
 --- !u!61 &292991393
 BoxCollider2D:
@@ -375,6 +456,24 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &302049289 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3170290366780529544, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+    type: 3}
+  m_PrefabInstance: {fileID: 690514614}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6e76c6accbeada4c8d2d9a2f024071f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &302049290 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+    type: 3}
+  m_PrefabInstance: {fileID: 690514614}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &319796911
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -386,6 +485,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Waypoint (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8236407040451445320, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_TagString
+      value: Untagged
       objectReference: {fileID: 0}
     - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
         type: 3}
@@ -827,6 +931,85 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!1001 &690514614
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 127082247}
+    m_Modifications:
+    - target: {fileID: 8236407040451445320, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_Name
+      value: Waypoint (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8236407040451445320, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -11.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.31677794
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3170290366780529544, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: next
+      value: 
+      objectReference: {fileID: 1698420888}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f2789e2148f46e040bc8d2f1f4814ce1, type: 3}
 --- !u!1 &886457837
 GameObject:
   m_ObjectHideFlags: 0
@@ -1247,6 +1430,7 @@ GameObject:
   - component: {fileID: 1370203877}
   - component: {fileID: 1370203876}
   - component: {fileID: 1370203875}
+  - component: {fileID: 1370203881}
   m_Layer: 0
   m_Name: PatrolCube
   m_TagString: Untagged
@@ -1377,6 +1561,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1370203881
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1370203874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: adbc5e6abd322594fa5e863e4a8dcdc4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1526366502
 GameObject:
   m_ObjectHideFlags: 0
@@ -1572,6 +1768,24 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1698420888 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3170290366780529544, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+    type: 3}
+  m_PrefabInstance: {fileID: 226924142}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6e76c6accbeada4c8d2d9a2f024071f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1698420890 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+    type: 3}
+  m_PrefabInstance: {fileID: 226924142}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1701187961
 GameObject:
   m_ObjectHideFlags: 0
@@ -1874,15 +2088,20 @@ PrefabInstance:
       propertyPath: m_Name
       value: Waypoint (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 8236407040451445320, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
     - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.35277557
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.44460058
+      value: -0.8
       objectReference: {fileID: 0}
     - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
         type: 3}
@@ -1933,6 +2152,6 @@ PrefabInstance:
         type: 3}
       propertyPath: next
       value: 
-      objectReference: {fileID: 1249976209}
+      objectReference: {fileID: 302049289}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f2789e2148f46e040bc8d2f1f4814ce1, type: 3}

--- a/bleak harbor/Assets/Scenes/AI test scene.unity
+++ b/bleak harbor/Assets/Scenes/AI test scene.unity
@@ -120,6 +120,38 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &127082246
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 127082247}
+  m_Layer: 0
+  m_Name: Waypoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &127082247
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 127082246}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5.1314297, y: 3.691966, z: -3.1370904}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1249976210}
+  - {fileID: 1182779761}
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &138996721
 GameObject:
   m_ObjectHideFlags: 0
@@ -199,6 +231,224 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 138996721}
   m_CullTransparentMesh: 0
+--- !u!1 &292991391
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 292991397}
+  - component: {fileID: 292991396}
+  - component: {fileID: 292991395}
+  - component: {fileID: 292991394}
+  - component: {fileID: 292991393}
+  - component: {fileID: 292991392}
+  m_Layer: 0
+  m_Name: WalkingCube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &292991392
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 292991391}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 11f92109c729fb34ca49e414ab8ce7a6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 20000
+  body: {fileID: 0}
+  fraction: 0
+  start: {fileID: 1249976209}
+--- !u!61 &292991393
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 292991391}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!50 &292991394
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 292991391}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 50
+  m_AngularDrag: 50
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!23 &292991395
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 292991391}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &292991396
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 292991391}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &292991397
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 292991391}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 23.46, y: 10.9, z: 0}
+  m_LocalScale: {x: 2.3308637, y: 2.3308637, z: 2.3308637}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &319796911
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 127082247}
+    m_Modifications:
+    - target: {fileID: 8236407040451445320, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_Name
+      value: Waypoint (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 25.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.4538684
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3170290366780529544, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: next
+      value: 
+      objectReference: {fileID: 1182779759}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f2789e2148f46e040bc8d2f1f4814ce1, type: 3}
 --- !u!1 &395676542
 GameObject:
   m_ObjectHideFlags: 0
@@ -700,7 +950,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 886457837}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 2.29, y: 4.21, z: 0}
+  m_LocalPosition: {x: 6.6, y: -16, z: 0}
   m_LocalScale: {x: 0.744, y: 0.761, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -743,7 +993,7 @@ Camera:
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.53017086, g: 0.59548175, b: 0.6981132, a: 0}
+  m_BackGroundColor: {r: 0.82745105, g: 0.82745105, b: 0.82745105, a: 0}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
@@ -927,7 +1177,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1151482870}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -5.94, y: 11.27, z: 0}
+  m_LocalPosition: {x: -5.94, y: 31.4, z: 0}
   m_LocalScale: {x: 5.182, y: 5.182, z: 5.182}
   m_Children: []
   m_Father: {fileID: 0}
@@ -947,6 +1197,186 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   speed: 9750
   body: {fileID: 0}
+--- !u!114 &1182779759 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3170290366780529544, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2023655886208345917}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6e76c6accbeada4c8d2d9a2f024071f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1182779761 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2023655886208345917}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1249976209 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3170290366780529544, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+    type: 3}
+  m_PrefabInstance: {fileID: 319796911}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6e76c6accbeada4c8d2d9a2f024071f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1249976210 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+    type: 3}
+  m_PrefabInstance: {fileID: 319796911}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1370203874
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1370203880}
+  - component: {fileID: 1370203879}
+  - component: {fileID: 1370203878}
+  - component: {fileID: 1370203877}
+  - component: {fileID: 1370203876}
+  - component: {fileID: 1370203875}
+  m_Layer: 0
+  m_Name: PatrolCube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1370203875
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1370203874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ee568a7704ae47e47a97aedfc4a7f002, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 16000
+  body: {fileID: 1370203877}
+  fraction: 1
+  patrolPivot: {x: 0, y: 0}
+--- !u!61 &1370203876
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1370203874}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!50 &1370203877
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1370203874}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 50
+  m_AngularDrag: 50
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!23 &1370203878
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1370203874}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1370203879
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1370203874}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1370203880
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1370203874}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 23.46, y: 10.9, z: 0}
+  m_LocalScale: {x: 2.3308637, y: 2.3308637, z: 2.3308637}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1526366502
 GameObject:
   m_ObjectHideFlags: 0
@@ -1136,7 +1566,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1527897840}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.59, y: -3.88, z: 0}
+  m_LocalPosition: {x: -0.5, y: -17.6, z: 0}
   m_LocalScale: {x: 0.744, y: 0.761, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -1266,7 +1696,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1701187961}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -6.16, y: -5.33, z: 0}
+  m_LocalPosition: {x: -21.8, y: -19.6, z: 0}
   m_LocalScale: {x: 0.744, y: 0.761, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -1432,3 +1862,77 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
+--- !u!1001 &2023655886208345917
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 127082247}
+    m_Modifications:
+    - target: {fileID: 8236407040451445320, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_Name
+      value: Waypoint (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.35277557
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.44460058
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.31677794
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013258534156695908, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3170290366780529544, guid: f2789e2148f46e040bc8d2f1f4814ce1,
+        type: 3}
+      propertyPath: next
+      value: 
+      objectReference: {fileID: 1249976209}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f2789e2148f46e040bc8d2f1f4814ce1, type: 3}

--- a/bleak harbor/Assets/Scripts/AI/Waypoint.cs
+++ b/bleak harbor/Assets/Scripts/AI/Waypoint.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using static BleakHarbor.Core.Utils;
+
+namespace BleakHarbor.AI
+{
+    /// <summary>
+    /// Представляет точку патрулирования.
+    /// Из таких точек собирается маршрут патрулирования.
+    /// </summary>
+    class Waypoint : MonoBehaviour
+    {
+        private new Transform transform;
+
+        /// <summary>
+        /// Показывает следующую точку патрулирования.
+        /// </summary>
+        public Waypoint Next { get => next; }
+        [SerializeField]
+        private Waypoint next;
+        
+
+        /// <summary>
+        /// Показывает, что на этой точке следует остановиться.
+        /// </summary>
+        public bool StopHere { get; }
+        [SerializeField]
+        private bool stopHere;
+
+        
+
+        public Vector2 Position { get => new Vector2(transform.position.x, transform.position.y); }
+
+        public void Start()
+        {
+            transform = this.GetComponent<Transform>();
+        }
+
+        public void Update()
+        {
+            Debug.DrawLine(Position, Next.Position);
+        }
+    }
+}

--- a/bleak harbor/Assets/Scripts/AI/WaypointDirectionFactory.cs
+++ b/bleak harbor/Assets/Scripts/AI/WaypointDirectionFactory.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using static BleakHarbor.Core.Utils;
+
+namespace BleakHarbor.AI
+{
+    internal class WaypointDirectionFactory
+    {
+        private Waypoint currentTarget;
+
+        /// <summary>
+        /// Точка, из в которой начинается движение.
+        /// </summary>
+        public Waypoint Start { get => start; }
+        private Waypoint start;
+
+        public Vector2 Position { get => positionFunc(); }
+        Func<Vector2> positionFunc;
+
+        public WaypointDirectionFactory(Waypoint start, Func<Vector2> position)
+        {
+            this.start = start;
+            positionFunc = position;
+            currentTarget = Start;
+        }
+
+        public Vector2 GetDirection()
+        {
+            if(Near(Position, currentTarget.Position))
+            {
+                currentTarget = currentTarget.Next;
+            }
+            return Vector2.ClampMagnitude(currentTarget.Position - Position, 1);
+        }
+    }
+}

--- a/bleak harbor/Assets/Scripts/AI/WaypointWalker.cs
+++ b/bleak harbor/Assets/Scripts/AI/WaypointWalker.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using UnityEngine;
+
+namespace BleakHarbor.AI
+{
+    public class WaypointWalker : Core.EntityWithFraction
+    {
+        [SerializeField]
+        private Waypoint start;
+
+        private WaypointDirectionFactory directionFactory;
+
+        public override Func<Vector2> DirectionFactory => directionFactory.GetDirection;
+
+        public new void Start()
+        {
+            base.Start();
+            directionFactory = new WaypointDirectionFactory(start, () => Position);
+        }
+    }
+
+}

--- a/bleak harbor/Assets/Scripts/Core/EntityBase.cs
+++ b/bleak harbor/Assets/Scripts/Core/EntityBase.cs
@@ -33,14 +33,14 @@ namespace BleakHarbor.Core
             body.AddForce(force, ForceMode2D.Force);
         }
 
-        void Start()
+        public void Start()
         {
             if (body == null)
             {
                 body = GetComponent<Rigidbody2D>();
             }
         }
-        void Update()
+        public void Update()
         {
             Move(DirectionFactory());
         }

--- a/bleak harbor/Assets/Scripts/Core/EntityWithFraction.cs
+++ b/bleak harbor/Assets/Scripts/Core/EntityWithFraction.cs
@@ -1,0 +1,25 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace BleakHarbor.Core
+{
+    public enum Fraction
+    {
+        Player,
+        Goberment
+    }
+    /// <summary>
+    /// Сущность, относящаяся к какой-либо фракции.
+    /// </summary>
+    /// <remarks>
+    /// Класс нужен, чтобы враги понимали что они враги а не друзья.
+    /// Допускаю, что введение понятия "фракция" сейчас - избыточно, но
+    /// таким образом у нас точно не возникнет ограничений. 
+    /// </remarks>
+    public abstract class EntityWithFraction : EntityBase
+    {
+        [SerializeField]
+        private Fraction fraction;
+        public Fraction Fraction { get => fraction; private set => fraction = value; }
+    }
+}

--- a/bleak harbor/Assets/Scripts/Core/Utils.cs
+++ b/bleak harbor/Assets/Scripts/Core/Utils.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace BleakHarbor.Core
+{
+    /// <summary>
+    /// В классе реализованы популярные общие методы.
+    /// </summary>
+    public static class Utils
+    {
+        /// <summary>
+        /// Возвращает истину, если вектор <paramref name="a"/> попадает в 
+        /// <paramref name="radius"/> окрестность вокруг вектора <paramref name="b"/>.
+        /// </summary>
+        /// <param name="radius">Радиус окрестности.</param>
+        public static bool Near(Vector2 a, Vector2 b, float radius = 0.5f)
+        {
+            return (b - a).magnitude < radius;
+        }
+    }
+}


### PR DESCRIPTION
Путевые точки (класс `Waypoint`) позволяют настроить траекторию движения сущности. Сами путевые точки представлены объектом на сцене, обладающим компонентом Waypoint и (опционально) ссылкой на следующую точку которую нужно посетить. 
В папку Prefabs теперь находится префаб Waypoint.
Чтобы их использовать, нужно добавить к объекту компонент WaypointWalker и установить стартовую точку.
Для удобства, путевая точка рисует линию до следующей точки **в окне редактора сцены** во время работы игры.

# Другое

Помимо этого, в ходе работы появился класс EntityWithFraction, которая просто позволяет установить фракцию, к которой принадлежит данная сущность.

В классе Utils я предполагаю иметь какие-то удобные мелочи. Например, я два раза копировал в разные классы метод Near, проверяющие что две точки находятся на небольшом расстоянии друг от друга. Подобные вещи я предлагаю держать в классе Utils.
